### PR TITLE
Alterações para garantir que as cartas só sejam jogadas no moldes atuais

### DIFF
--- a/Interface/Cards/Estados_cartas/card_released_state.gd
+++ b/Interface/Cards/Estados_cartas/card_released_state.gd
@@ -1,6 +1,19 @@
 extends CardState
 
+var played: bool
 
 func enter() -> void:
 	card_ui.color.color = Color.DARK_MAGENTA
 	card_ui.state.text = "RELEASED"
+
+	played = false
+	
+	if not card_ui.targets.is_empty():
+		played = true
+		print("play card for targets: ", card_ui.targets)
+
+func on_input(_event: InputEvent) -> void:
+	if played:
+		return
+		
+	transition_requested.emit(self, CardState.State.BASE)

--- a/Interface/Cards/card_ui.gd
+++ b/Interface/Cards/card_ui.gd
@@ -11,6 +11,8 @@ signal reparent_requested(which_card_ui: CardUI)
 @onready var state: Label = $State
 @onready var card_state_machine: CardStateMachine = $CardStateMachine as CardStateMachine
 @onready var drop_point_detector: Area2D = $DropPointDetector
+@onready var targets: Array[Node] = []
+
 
 func _ready() -> void:
 	card_state_machine.init(self)
@@ -26,3 +28,10 @@ func _on_mouse_entered() -> void:
 	
 func _on_mouse_exited() -> void:
 	card_state_machine.on_mouse_exited()
+
+func _on_drop_point_detector_area_entered(area: Area2D) -> void:
+	if not targets.has(area):
+		targets.append(area)
+	
+func _on_drop_point_detector_area_exited(area: Area2D) -> void:
+	targets.erase(area)

--- a/Interface/Cards/card_ui.tscn
+++ b/Interface/Cards/card_ui.tscn
@@ -47,7 +47,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="DropPointDetector" type="Area2D" parent="."]
-collision_mask = 2
+collision_mask = 3
 monitorable = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="DropPointDetector"]
@@ -76,3 +76,5 @@ state = 1
 [connection signal="gui_input" from="." to="." method="_on_gui_input"]
 [connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]
+[connection signal="area_entered" from="DropPointDetector" to="." method="_on_drop_point_detector_area_entered"]
+[connection signal="area_exited" from="DropPointDetector" to="." method="_on_drop_point_detector_area_exited"]

--- a/Interface/Tabuleiro/Cartas/Molde_Cartas.tscn
+++ b/Interface/Tabuleiro/Cartas/Molde_Cartas.tscn
@@ -27,32 +27,32 @@ texture = ExtResource("2_nflqd")
 position = Vector2(428.931, 0)
 texture = ExtResource("2_nflqd")
 
-[node name="StaticBody2D" type="StaticBody2D" parent="Cartas"]
+[node name="Area2D" type="Area2D" parent="Cartas"]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/StaticBody2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/Area2D"]
 position = Vector2(0, -2.54313e-06)
 shape = SubResource("RectangleShape2D_4rtda")
 
-[node name="StaticBody2D2" type="StaticBody2D" parent="Cartas"]
+[node name="Area2D2" type="Area2D" parent="Cartas"]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/StaticBody2D2"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/Area2D2"]
 position = Vector2(429.104, 0)
 shape = SubResource("RectangleShape2D_4rtda")
 
-[node name="StaticBody2D3" type="StaticBody2D" parent="Cartas"]
+[node name="Area2D3" type="Area2D" parent="Cartas"]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/StaticBody2D3"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/Area2D3"]
 position = Vector2(858.209, 0)
 shape = SubResource("RectangleShape2D_4rtda")
 
-[node name="StaticBody2D4" type="StaticBody2D" parent="Cartas"]
+[node name="Area2D4" type="Area2D" parent="Cartas"]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/StaticBody2D4"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/Area2D4"]
 position = Vector2(-429.104, 0)
 shape = SubResource("RectangleShape2D_4rtda")
 
-[node name="StaticBody2D5" type="StaticBody2D" parent="Cartas"]
+[node name="Area2D5" type="Area2D" parent="Cartas"]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/StaticBody2D5"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cartas/Area2D5"]
 position = Vector2(-858.209, 0)
 shape = SubResource("RectangleShape2D_4rtda")

--- a/Interface/Tabuleiro/level.tscn
+++ b/Interface/Tabuleiro/level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://bay58o83da5vq"]
+[gd_scene load_steps=18 format=3 uid="uid://bay58o83da5vq"]
 
 [ext_resource type="Script" path="res://Interface/Tabuleiro/level.gd" id="1_nj2sr"]
 [ext_resource type="PackedScene" uid="uid://dg5wkrbh7023v" path="res://Interface/Cards/card_ui.tscn" id="2_kicwl"]
@@ -7,10 +7,9 @@
 [ext_resource type="Texture2D" uid="uid://djdnecw6v3n7u" path="res://Imagens/Tabuleiro/Viridianos/parte_grama.png" id="4_0mnjs"]
 [ext_resource type="Texture2D" uid="uid://cm3gx7jnplhbx" path="res://Imagens/Tabuleiro/Ophidianos/Parte_robo.png" id="4_lec2h"]
 [ext_resource type="Texture2D" uid="uid://ccwuigx8bnpsp" path="res://Imagens/Tabuleiro/Fratura_central.jpg" id="6_gkgke"]
-
-[ext_resource type="PackedScene" uid="uid://b5apejntrk478" path="res://Interface/Tabuleiro/Cartas/Molde_Cartas.tscn" id="9_a54r5"]
 [ext_resource type="Script" path="res://Interface/Tabuleiro/hand.gd" id="7_m8cp8"]
 [ext_resource type="Resource" uid="uid://d2uq7oqtfrcj2" path="res://Personagens/Ophidianos/cards/general_ophidiano.tres" id="9_0s437"]
+[ext_resource type="PackedScene" uid="uid://b5apejntrk478" path="res://Interface/Tabuleiro/Cartas/Molde_Cartas.tscn" id="9_a54r5"]
 [ext_resource type="Resource" uid="uid://dptfyws7k8xxi" path="res://Personagens/Ophidianos/cards/lider_ophidiano.tres" id="10_cdwk2"]
 [ext_resource type="Resource" uid="uid://cgxis8dhu6lb6" path="res://Personagens/Ophidianos/cards/soldado_ophidiano.tres" id="11_ybjyr"]
 [ext_resource type="Resource" uid="uid://c5tapafa7lxm5" path="res://Personagens/Viridianos/cards/soldado_viridiano.tres" id="12_vo774"]


### PR DESCRIPTION
Ligação do sinal de "area" dos moldes com o drop detector do card_ui. Alteração no card_state_released para garantir que somente dentro dessas áreas as cartas sejam jogadas